### PR TITLE
Changes the buildpacks id 

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.2"
 
 [buildpack]
-  id = "paketo-buildpacks/mri"
+  id = "paketo-community/mri"
   name = "MRI Buildpack"
   version = "{{ .Version }}"
 

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -65,7 +65,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
-				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-buildpacks_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-community_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
 			}
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence(sequence), logs.String())

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -72,7 +72,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(1))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/mri"))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-community/mri"))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("mri"))
 
 			buildpackVersion, err := GetGitVersion()
@@ -91,7 +91,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
-				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-buildpacks_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-community_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
 			}), logs.String())
 
 			firstContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(firstImage.ID)
@@ -111,7 +111,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(1))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/mri"))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-community/mri"))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("mri"))
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
@@ -122,7 +122,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
 				"",
-				"  Reusing cached layer /layers/paketo-buildpacks_mri/mri",
+				"  Reusing cached layer /layers/paketo-community_mri/mri",
 			}), logs.String())
 
 			secondContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(secondImage.ID)
@@ -165,7 +165,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(1))
-			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/mri"))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal("paketo-community/mri"))
 			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("mri"))
 
 			buildpackVersion, err := GetGitVersion()
@@ -184,7 +184,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
-				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-buildpacks_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/paketo-community_mri/mri/lib/ruby/gems/2\.7\.\d+"`),
 			}), logs.String())
 
 			firstContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(firstImage.ID)
@@ -204,7 +204,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(1))
-			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-buildpacks/mri"))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal("paketo-community/mri"))
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("mri"))
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
@@ -220,7 +220,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
-				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.6\.\d+:/layers/paketo-buildpacks_mri/mri/lib/ruby/gems/2\.6\.\d+"`),
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.6\.\d+:/layers/paketo-community_mri/mri/lib/ruby/gems/2\.6\.\d+"`),
 			}), logs.String())
 
 			secondContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(secondImage.ID)


### PR DESCRIPTION
The buildpack id pointed at `paketo-buildpacks` instead of `paketo-community` this PR fixes that error.