### PR TITLE
Rename MRI dependencies to "Ruby"

### DIFF
--- a/build.go
+++ b/build.go
@@ -41,10 +41,21 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery B
 
 		entry := entries.Resolve(context.Plan.Entries)
 
+		// NOTE: this is to override that the dependency is called "ruby" in the
+		// buildpack.toml. We can remove this once we update our own dependencies
+		// and can name it however we like.
+		entry.Name = "ruby"
+
 		dependency, err := dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, entry.Version, context.Stack)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}
+
+		// NOTE: this is to override that the dependency is called "ruby" in the
+		// buildpack.toml. We can remove this once we update our own dependencies
+		// and can name it however we like.
+		dependency.ID = "mri"
+		dependency.Name = "MRI"
 
 		logger.SelectedDependency(entry, dependency, clock.Now())
 

--- a/build_test.go
+++ b/build_test.go
@@ -75,7 +75,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		dependencyManager = &fakes.DependencyManager{}
-		dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{Name: "MRI"}
+		dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{ID: "ruby", Name: "Ruby"}
 
 		planRefinery = &fakes.BuildPlanRefinery{}
 
@@ -183,14 +183,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}))
 
 		Expect(dependencyManager.ResolveCall.Receives.Path).To(Equal(filepath.Join(cnbDir, "buildpack.toml")))
-		Expect(dependencyManager.ResolveCall.Receives.Id).To(Equal("mri"))
+		Expect(dependencyManager.ResolveCall.Receives.Id).To(Equal("ruby"))
 		Expect(dependencyManager.ResolveCall.Receives.Version).To(Equal("2.5.x"))
 		Expect(dependencyManager.ResolveCall.Receives.Stack).To(Equal("some-stack"))
 
 		Expect(planRefinery.BillOfMaterialCall.CallCount).To(Equal(1))
-		Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "MRI"}))
+		Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{ID: "mri", Name: "MRI"}))
 
-		Expect(dependencyManager.InstallCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "MRI"}))
+		Expect(dependencyManager.InstallCall.Receives.Dependency).To(Equal(postal.Dependency{ID: "mri", Name: "MRI"}))
 		Expect(dependencyManager.InstallCall.Receives.CnbPath).To(Equal(cnbDir))
 		Expect(dependencyManager.InstallCall.Receives.LayerPath).To(Equal(filepath.Join(layersDir, "mri")))
 
@@ -374,7 +374,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{
-				Name:   "MRI",
+				ID:     "ruby",
+				Name:   "Ruby",
 				SHA256: "some-sha",
 			}
 		})
@@ -405,6 +406,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(planRefinery.BillOfMaterialCall.CallCount).To(Equal(1))
 			Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{
+				ID:     "mri",
 				Name:   "MRI",
 				SHA256: "some-sha",
 			}))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,7 +9,7 @@ api = "0.2"
   include_files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
   pre_package = "./scripts/build.sh"
   [metadata.default-versions]
-    mri = "2.7.*"
+    ruby = "2.7.*"
 
   [[metadata.dependencies]]
     id = "ruby"
@@ -75,7 +75,7 @@ api = "0.2"
   [[metadata.dependency_deprecation_dates]]
     date = 2023-04-01T00:00:00Z
     link = "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/"
-    name = "mri"
+    name = "ruby"
     version_line = "2.7.x"
 
 [[stacks]]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,77 +12,35 @@ api = "0.2"
     mri = "2.7.*"
 
   [[metadata.dependencies]]
-    id = "mri"
-    name = "MRI"
+    id = "ruby"
+    name = "Ruby"
     sha256 = "01b7d7a8a3031f15079e0ca1245e002575f47c8943f68508d86ba4f46ac24190"
     source = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz"
     source_sha256 = "0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4"
     stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.5.7-linux-x64-cflinuxfs3-01b7d7a8.tgz"
     version = "2.5.7"
-
+   
   [[metadata.dependencies]]
-    id = "mri"
-    name = "MRI"
-    sha256 = "738900eab9e0cb8139415556d4022d6d9c4947ed7c46f78862785028f45fa239"
+    id = "ruby"
+    name = "Ruby"
+    sha256 = "4749d33a4385cb5cc61dd6e460d474132277fda76cc542e1cdfe45b0df93bdc8"
     source = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz"
     source_sha256 = "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.5.8_linux_x64_cflinuxfs3_738900ea.tgz"
+    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.5.8_linux_x64_cflinuxfs3_4749d33a.tgz"
     version = "2.5.8"
 
   [[metadata.dependencies]]
-    id = "mri"
-    name = "MRI"
+    id = "ruby"
+    name = "Ruby"
     sha256 = "a23c26ec93e34ca05328390107ff40034b5103afb91194ebf70f66f0c0866db4"
     source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz"
     source_sha256 = "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d"
     stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.6.5-linux-x64-cflinuxfs3-a23c26ec.tgz"
     version = "2.6.5"
-
-  [[metadata.dependencies]]
-    id = "mri"
-    name = "MRI"
-    sha256 = "9f860a6520bf8774fcb06ea9a33ae17818875b747b58ca11b0690223c7126493"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz"
-    source_sha256 = "364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.6.6_linux_x64_cflinuxfs3_9f860a65.tgz"
-    version = "2.6.6"
-
-  [[metadata.dependencies]]
-    id = "mri"
-    name = "MRI"
-    sha256 = "68cd2baeb33c1f10a873aab8e492d4547f3b13d1a6302930ac25bcedf45d51ce"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz"
-    source_sha256 = "8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.7.0-linux-x64-cflinuxfs3-68cd2bae.tgz"
-    version = "2.7.0"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2023-04-01T00:00:00Z"
-    id = "mri"
-    name = "MRI"
-    sha256 = "e25620088c536685f81aaae0f7f03c2143aa3dc9078a99707168915e85568f04"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz"
-    source_sha256 = "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.7.1_linux_x64_cflinuxfs3_e2562008.tgz"
-    version = "2.7.1"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2023-04-01T00:00:00Z"
-    id = "ruby"
-    name = "Ruby"
-    sha256 = "c892f69b474a9669320b11b324f1a3efb4bc7a8a6409f4274aef0056a82a2161"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz"
-    source_sha256 = "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.7.1_linux_x64_cflinuxfs3_c892f69b.tgz"
-    version = "2.7.1"
-
+    
   [[metadata.dependencies]]
     id = "ruby"
     name = "Ruby"
@@ -96,12 +54,23 @@ api = "0.2"
   [[metadata.dependencies]]
     id = "ruby"
     name = "Ruby"
-    sha256 = "4749d33a4385cb5cc61dd6e460d474132277fda76cc542e1cdfe45b0df93bdc8"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz"
-    source_sha256 = "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a"
+    sha256 = "68cd2baeb33c1f10a873aab8e492d4547f3b13d1a6302930ac25bcedf45d51ce"
+    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz"
+    source_sha256 = "8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe"
+    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.7.0-linux-x64-cflinuxfs3-68cd2bae.tgz"
+    version = "2.7.0"
+
+  [[metadata.dependencies]]
+    deprecation_date = "2023-04-01T00:00:00Z"
+    id = "ruby"
+    name = "Ruby"
+    sha256 = "c892f69b474a9669320b11b324f1a3efb4bc7a8a6409f4274aef0056a82a2161"
+    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz"
+    source_sha256 = "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.5.8_linux_x64_cflinuxfs3_4749d33a.tgz"
-    version = "2.5.8"
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_2.7.1_linux_x64_cflinuxfs3_c892f69b.tgz"
+    version = "2.7.1"
 
   [[metadata.dependency_deprecation_dates]]
     date = 2023-04-01T00:00:00Z


### PR DESCRIPTION
this is to preserve parity  with releng's pipelines as they auto-update this .toml using the "ruby" naming convention.