### PR TITLE
Move main.go into run sub-package

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"bytes"

--- a/build_test.go
+++ b/build_test.go
@@ -1,4 +1,4 @@
-package main_test
+package mri_test
 
 import (
 	"bytes"
@@ -14,7 +14,7 @@ import (
 	"github.com/paketo-buildpacks/packit/chronos"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/paketo-buildpacks/packit/postal"
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/paketo-community/mri/fakes"
 	"github.com/sclevine/spec"
 
@@ -100,14 +100,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		buffer = bytes.NewBuffer(nil)
-		logEmitter := main.NewLogEmitter(buffer)
+		logEmitter := mri.NewLogEmitter(buffer)
 		gem = &fakes.Executable{}
 		gem.ExecuteCall.Stub = func(execution pexec.Execution) error {
 			fmt.Fprintln(execution.Stdout, "/some/mri/gems/path")
 			return nil
 		}
 
-		build = main.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock, gem)
+		build = mri.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock, gem)
 	})
 
 	it.After(func() {
@@ -164,8 +164,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Launch:    true,
 					Cache:     false,
 					Metadata: map[string]interface{}{
-						main.DepKey: "",
-						"built_at":  timeStamp.Format(time.RFC3339Nano),
+						mri.DepKey: "",
+						"built_at": timeStamp.Format(time.RFC3339Nano),
 					},
 				},
 			},
@@ -291,8 +291,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Launch:    true,
 						Cache:     true,
 						Metadata: map[string]interface{}{
-							main.DepKey: "",
-							"built_at":  timeStamp.Format(time.RFC3339Nano),
+							mri.DepKey: "",
+							"built_at": timeStamp.Format(time.RFC3339Nano),
 						},
 					},
 				},
@@ -361,8 +361,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Launch:    true,
 						Cache:     false,
 						Metadata: map[string]interface{}{
-							main.DepKey: "",
-							"built_at":  timeStamp.Format(time.RFC3339Nano),
+							mri.DepKey: "",
+							"built_at": timeStamp.Format(time.RFC3339Nano),
 						},
 					},
 				},
@@ -506,7 +506,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		context("when the layer directory cannot be removed", func() {
 			var layerDir string
 			it.Before(func() {
-				layerDir = filepath.Join(layersDir, main.MRI)
+				layerDir = filepath.Join(layersDir, mri.MRI)
 				Expect(os.MkdirAll(filepath.Join(layerDir, "baller"), os.ModePerm)).To(Succeed())
 				Expect(os.Chmod(layerDir, 0000)).To(Succeed())
 			})

--- a/buildpack_yml_parser.go
+++ b/buildpack_yml_parser.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"os"

--- a/buildpack_yml_parser_test.go
+++ b/buildpack_yml_parser_test.go
@@ -1,11 +1,11 @@
-package main_test
+package mri_test
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -16,7 +16,7 @@ func testBuildpackYMLParser(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		path   string
-		parser main.BuildpackYMLParser
+		parser mri.BuildpackYMLParser
 	)
 
 	it.Before(func() {
@@ -32,7 +32,7 @@ mri:
 
 		path = file.Name()
 
-		parser = main.NewBuildpackYMLParser()
+		parser = mri.NewBuildpackYMLParser()
 	})
 
 	it.After(func() {

--- a/constants.go
+++ b/constants.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 const (
 	MRI                = "mri"

--- a/detect.go
+++ b/detect.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"path/filepath"

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,11 +1,11 @@
-package main_test
+package mri_test
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit"
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/paketo-community/mri/fakes"
 	"github.com/sclevine/spec"
 
@@ -23,7 +23,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		buildpackYMLParser = &fakes.VersionParser{}
 
-		detect = main.Detect(buildpackYMLParser)
+		detect = mri.Detect(buildpackYMLParser)
 	})
 
 	it("returns a plan that provides mri", func() {
@@ -33,7 +33,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Plan).To(Equal(packit.BuildPlan{
 			Provides: []packit.BuildPlanProvision{
-				{Name: main.MRI},
+				{Name: mri.MRI},
 			},
 		}))
 	})
@@ -50,13 +50,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{
-					{Name: main.MRI},
+					{Name: mri.MRI},
 				},
 				Requires: []packit.BuildPlanRequirement{
 					{
-						Name:    main.MRI,
+						Name:    mri.MRI,
 						Version: "4.5.6",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: mri.BuildPlanMetadata{
 							VersionSource: "buildpack.yml",
 						},
 					},

--- a/init_test.go
+++ b/init_test.go
@@ -1,4 +1,4 @@
-package main_test
+package mri_test
 
 import (
 	"testing"

--- a/log_emitter.go
+++ b/log_emitter.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"io"

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -1,4 +1,4 @@
-package main_test
+package mri_test
 
 import (
 	"bytes"
@@ -7,7 +7,7 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/postal"
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -18,12 +18,12 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		buffer  *bytes.Buffer
-		emitter main.LogEmitter
+		emitter mri.LogEmitter
 	)
 
 	it.Before(func() {
 		buffer = bytes.NewBuffer(nil)
-		emitter = main.NewLogEmitter(buffer)
+		emitter = mri.NewLogEmitter(buffer)
 	})
 
 	context("SelectedDependency", func() {

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"sort"

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -1,11 +1,11 @@
-package main_test
+package mri_test
 
 import (
 	"bytes"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit"
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -16,12 +16,12 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		buffer   *bytes.Buffer
-		resolver main.PlanEntryResolver
+		resolver mri.PlanEntryResolver
 	)
 
 	it.Before(func() {
 		buffer = bytes.NewBuffer(nil)
-		resolver = main.NewPlanEntryResolver(main.NewLogEmitter(buffer))
+		resolver = mri.NewPlanEntryResolver(mri.NewLogEmitter(buffer))
 	})
 
 	context("when a buildpack.yml entry is included", func() {

--- a/plan_refinery.go
+++ b/plan_refinery.go
@@ -1,4 +1,4 @@
-package main
+package mri
 
 import (
 	"github.com/paketo-buildpacks/packit"

--- a/plan_refinery_test.go
+++ b/plan_refinery_test.go
@@ -1,10 +1,10 @@
-package main_test
+package mri_test
 
 import (
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/postal"
-	main "github.com/paketo-community/mri"
+	"github.com/paketo-community/mri"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -14,11 +14,11 @@ func testPlanRefinery(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		planRefinery main.PlanRefinery
+		planRefinery mri.PlanRefinery
 	)
 
 	it.Before(func() {
-		planRefinery = main.NewPlanRefinery()
+		planRefinery = mri.NewPlanRefinery()
 	})
 
 	context("BillOfMaterial", func() {

--- a/run/main.go
+++ b/run/main.go
@@ -8,18 +8,26 @@ import (
 	"github.com/paketo-buildpacks/packit/chronos"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/paketo-buildpacks/packit/postal"
+	"github.com/paketo-community/mri"
 )
 
 func main() {
-	buildpackYMLParser := NewBuildpackYMLParser()
-	logEmitter := NewLogEmitter(os.Stdout)
-	entryResolver := NewPlanEntryResolver(logEmitter)
+	buildpackYMLParser := mri.NewBuildpackYMLParser()
+	logEmitter := mri.NewLogEmitter(os.Stdout)
+	entryResolver := mri.NewPlanEntryResolver(logEmitter)
 	dependencyManager := postal.NewService(cargo.NewTransport())
-	planRefinery := NewPlanRefinery()
+	planRefinery := mri.NewPlanRefinery()
 	gem := pexec.NewExecutable("gem")
 
 	packit.Run(
-		Detect(buildpackYMLParser),
-		Build(entryResolver, dependencyManager, planRefinery, logEmitter, chronos.DefaultClock, gem),
+		mri.Detect(buildpackYMLParser),
+		mri.Build(
+			entryResolver,
+			dependencyManager,
+			planRefinery,
+			logEmitter,
+			chronos.DefaultClock,
+			gem,
+		),
 	)
 }


### PR DESCRIPTION
This ensures that we don't have issues with importing main if that needs to happen.