### PR TITLE
Replaces unsafe type-assertion with safe call

### DIFF
--- a/build.go
+++ b/build.go
@@ -46,8 +46,9 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery B
 		// buildpack.toml. We can remove this once we update our own dependencies
 		// and can name it however we like.
 		entry.Name = "ruby"
+		version, _ := entry.Metadata["version"].(string)
 
-		dependency, err := dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, entry.Metadata["version"].(string), context.Stack)
+		dependency, err := dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, version, context.Stack)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}


### PR DESCRIPTION
When calling `entry.Metadata["version"].(string)`, the code is making an assertion about the type of the value in the map. However, if the value does not exist in the map, then the type assertion will fail as `nil` is not a `string`. When the assertion fails, the Go runtime will panic, crashing the program.

This has been replaced with a call that returns 2 values: 1) a value that has been asserted to be a `string`, and 2) a value indicating whether the type assertion succeeded. In this case, we do not need to check that the assertion succeeded, and so we have discarded that value. For the returned `string` value, the default will be an empty string which is precisely what we want if the version was not specified in the `entry.Metadata` map.

More details about type assertions in Go can be found in the Effective Go documentation: https://golang.org/doc/effective_go.html#interface_conversions.